### PR TITLE
[Feat] Question 엔티티 생성

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
@@ -1,0 +1,23 @@
+package hunzz.study.moorobo.domain.question.model
+
+import hunzz.study.moorobo.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "questions")
+class Question(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: QuestionStatus,
+
+    @Column(name = "title", nullable = false)
+    val title: String,
+
+    @Column(name = "content", nullable = false)
+    val content: String
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/model/QuestionStatus.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/model/QuestionStatus.kt
@@ -1,0 +1,5 @@
+package hunzz.study.moorobo.domain.question.model
+
+enum class QuestionStatus {
+    NORMAL, DELETED
+}

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -1,0 +1,32 @@
+package hunzz.study.moorobo.domain.question.controller
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest
+class QuestionControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Test
+    @DisplayName("")
+    fun addQuestion() {
+        mockMvc.perform(
+            post("/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("name", "John")
+        ).andExpect(status().isCreated)
+            .andExpect(content().string(""))
+            .andDo(print())
+
+
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #3 

## 작업 내용

- [x] Question 엔티티 생성 -> status, title, content
- [x] Question의 상태를 담을 QuestionStatus enum 클래스 생성 -> NORMAL, DELETED

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
