### PR TITLE
[Feat] 질문 등록 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -1,12 +1,24 @@
 package hunzz.study.moorobo.domain.question.controller
 
+import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
 import hunzz.study.moorobo.domain.question.service.QuestionService
+import jakarta.validation.Valid
+import org.springframework.context.annotation.Description
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URI
 
 @RestController
 @RequestMapping("/questions")
 class QuestionController(
     private val questionService: QuestionService
 ) {
+    @PostMapping
+    @Description("질문 등록")
+    fun addQuestion(@Valid @RequestBody request: AddQuestionRequest) =
+        questionService.addQuestion(request)
+            .let { ResponseEntity.created(URI.create("/questions/${it.id}")).body(it) }
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/AddQuestionRequest.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/AddQuestionRequest.kt
@@ -1,0 +1,22 @@
+package hunzz.study.moorobo.domain.question.dto
+
+import hunzz.study.moorobo.domain.question.model.Question
+import hunzz.study.moorobo.domain.question.model.QuestionStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class AddQuestionRequest(
+    @field:NotBlank(message = "질문의 제목은 필수 입력 항목입니다.")
+    @field:Size(max = 128, message = "질문의 제목은 128자 이하여야 합니다.")
+    val title: String,
+
+    @field:NotBlank(message = "질문의 내용은 필수 입력 항목입니다.")
+    val content: String
+) {
+    // Request -> Entity
+    fun to() = Question(
+        status = QuestionStatus.NORMAL,
+        title = this.title,
+        content = this.content
+    )
+}

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/QuestionResponse.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/QuestionResponse.kt
@@ -1,0 +1,18 @@
+package hunzz.study.moorobo.domain.question.dto
+
+import hunzz.study.moorobo.domain.question.model.Question
+
+data class QuestionResponse(
+    val id: Long,
+    val title: String,
+    val content: String
+) {
+    companion object {
+        // Entity -> Response
+        fun from(question: Question) = QuestionResponse(
+            id = question.id!!,
+            title = question.title,
+            content = question.content
+        )
+    }
+}

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -1,10 +1,18 @@
 package hunzz.study.moorobo.domain.question.service
 
+import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.dto.QuestionResponse
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
+import org.springframework.context.annotation.Description
 import org.springframework.stereotype.Service
 
 @Service
 class QuestionService(
     private val questionRepository: QuestionRepository
 ) {
+    @Description("질문 등록")
+    fun addQuestion(request: AddQuestionRequest) =
+        request.to()
+            .let { questionRepository.save(it) }
+            .let { QuestionResponse.from(it) }
 }

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -3,30 +3,83 @@ package hunzz.study.moorobo.domain.question.controller
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
-@WebMvcTest
+@SpringBootTest
+@AutoConfigureMockMvc
 class QuestionControllerTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 
     @Test
-    @DisplayName("")
+    @DisplayName("정상적으로 질문이 등록되는 경우")
     fun addQuestion() {
         mockMvc.perform(
             post("/questions")
                 .contentType(MediaType.APPLICATION_JSON)
-                .param("name", "John")
+                .content(
+                    """
+                        {
+                          "title": "테스트 제목",
+                          "content": "테스트 내용"
+                        }    
+                    """.trimIndent()
+                )
         ).andExpect(status().isCreated)
-            .andExpect(content().string(""))
+            .andExpect(jsonPath("$.title").value("테스트 제목"))
+            .andExpect(jsonPath("$.content").value("테스트 내용"))
             .andDo(print())
+    }
 
+    @Test
+    @DisplayName("질문의 제목과 내용을 미입력한 경우")
+    fun addQuestionException1() {
+        mockMvc.perform(
+            post("/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                        {
+                          "title": "",
+                          "content": ""
+                        }    
+                    """.trimIndent()
+                )
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errors").isArray)
+            .andExpect(jsonPath("$.errors.size()").value(2))
+            .andExpect(jsonPath("$.errors[0].field").value("title"))
+            .andExpect(jsonPath("$.errors[0].message").value("질문의 제목은 필수 입력 항목입니다."))
+            .andExpect(jsonPath("$.errors[1].field").value("content"))
+            .andExpect(jsonPath("$.errors[1].message").value("질문의 내용은 필수 입력 항목입니다."))
+            .andDo(print())
+    }
 
+    @Test
+    @DisplayName("255자를 초과하는 질문 제목이 등록된 경우")
+    fun addQuestionException2() {
+        mockMvc.perform(
+            post("/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                        {
+                          "title": "${"테스트".repeat(43)}",
+                          "content": "테스트 내용"
+                        }    
+                    """.trimIndent()
+                )
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errors").isArray)
+            .andExpect(jsonPath("$.errors.size()").value(1))
+            .andExpect(jsonPath("$.errors[0].field").value("title"))
+            .andExpect(jsonPath("$.errors[0].message").value("질문의 제목은 128자 이하여야 합니다."))
+            .andDo(print())
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #11

## 작업 내용

- [x] QuestionController와 QuestionService에 addQuestion 메서드 추가
- [x] 질문 등록 관련 데이터를 받아올 AddQuestionRequest DTO 클래스 생성 및 Validation 적용
- [x] 해당 질문 등록 후, 관련 데이터를 전달할 QuestionResponse DTO 클래스 생성
- [x] 질문 등록 기능 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
