### PR TITLE
[Feat] 질문 단건 조회 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -5,10 +5,7 @@ import hunzz.study.moorobo.domain.question.service.QuestionService
 import jakarta.validation.Valid
 import org.springframework.context.annotation.Description
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @RestController
@@ -21,4 +18,9 @@ class QuestionController(
     fun addQuestion(@Valid @RequestBody request: AddQuestionRequest) =
         questionService.addQuestion(request)
             .let { ResponseEntity.created(URI.create("/questions/${it.id}")).body(it) }
+
+    @GetMapping("/{questionId}")
+    @Description("질문 단건 조회")
+    fun findQuestion(@PathVariable questionId: Long) =
+        questionService.findQuestion(questionId)
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -4,15 +4,25 @@ import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
 import hunzz.study.moorobo.domain.question.dto.QuestionResponse
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import org.springframework.context.annotation.Description
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class QuestionService(
     private val questionRepository: QuestionRepository
 ) {
+    @Description("질문 id로 질문 엔티티를 가져오는 내부 메서드")
+    private fun getQuestionById(questionId: Long) =
+        questionRepository.findByIdOrNull(questionId) ?: throw Exception("") // TODO : 추후 별도의 Exception 생성
+
     @Description("질문 등록")
     fun addQuestion(request: AddQuestionRequest) =
         request.to()
             .let { questionRepository.save(it) }
+            .let { QuestionResponse.from(it) }
+
+    @Description("질문 단건 조회")
+    fun findQuestion(questionId: Long) =
+        getQuestionById(questionId)
             .let { QuestionResponse.from(it) }
 }

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -2,6 +2,9 @@ package hunzz.study.moorobo.domain.question.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.model.Question
+import hunzz.study.moorobo.domain.question.model.QuestionStatus
+import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -23,19 +27,23 @@ class QuestionControllerTest {
     @Autowired
     lateinit var objectMapper: ObjectMapper
 
+    @Autowired
+    lateinit var questionRepository: QuestionRepository
+
     @Test
     @DisplayName("정상적으로 질문이 등록되는 경우")
     fun addQuestion() {
+        // given
         val json = objectMapper.writeValueAsString(
             AddQuestionRequest(title = "테스트 제목", content = "테스트 내용")
         )
 
+        // expected
         mockMvc.perform(
             post("/questions")
                 .contentType(APPLICATION_JSON)
                 .content(json)
         ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.title").value("테스트 제목"))
             .andExpect(jsonPath("$.content").value("테스트 내용"))
             .andDo(print())
@@ -44,10 +52,12 @@ class QuestionControllerTest {
     @Test
     @DisplayName("질문의 내용을 미입력한 경우")
     fun addQuestionException1() {
+        // given
         val json = objectMapper.writeValueAsString(
             AddQuestionRequest(title = "테스트 제목", content = "")
         )
 
+        // expected
         mockMvc.perform(
             post("/questions")
                 .contentType(APPLICATION_JSON)
@@ -62,10 +72,12 @@ class QuestionControllerTest {
     @Test
     @DisplayName("128자를 초과하는 질문 제목이 등록된 경우")
     fun addQuestionException2() {
+        // given
         val json = objectMapper.writeValueAsString(
             AddQuestionRequest(title = "테스트".repeat(43), content = "테스트 내용")
         )
 
+        // expected
         mockMvc.perform(
             post("/questions")
                 .contentType(APPLICATION_JSON)
@@ -76,5 +88,23 @@ class QuestionControllerTest {
             .andExpect(jsonPath("$.errors[0].field").value("title"))
             .andExpect(jsonPath("$.errors[0].message").value("질문의 제목은 128자 이하여야 합니다."))
             .andDo(print())
+    }
+
+    @Test
+    @DisplayName("정상적으로 질문이 조회된 경우")
+    fun findQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // expected
+        mockMvc.perform(
+            get("/questions/{questionId}", existingQuestion.id)
+                .contentType(APPLICATION_JSON)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(existingQuestion.id))
+            .andExpect(jsonPath("$.title").value("테스트 제목"))
+            .andExpect(jsonPath("$.content").value("테스트 내용"))
     }
 }

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -1,13 +1,15 @@
 package hunzz.study.moorobo.domain.question.service
 
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.model.Question
+import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.repository.findByIdOrNull
 
 @SpringBootTest
 class QuestionServiceTest {
@@ -23,18 +25,33 @@ class QuestionServiceTest {
     }
 
     @Test
+    @DisplayName("질문 등록")
     fun addQuestion() {
         // given
         val request = AddQuestionRequest(title = "테스트 제목", content = "테스트 내용")
 
         // when
-        questionService.addQuestion(request)
+        val question = questionService.addQuestion(request)
 
         // then
         assertEquals(1, questionRepository.count())
-        questionRepository.findByIdOrNull(1L).let {
-            assertEquals("테스트 제목", it!!.title)
-            assertEquals("테스트 내용", it.content)
-        }
+        assertEquals("테스트 제목", question.title)
+        assertEquals("테스트 내용", question.content)
+    }
+
+    @Test
+    @DisplayName("질문 단건 조회")
+    fun findQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // when
+        val question = questionService.findQuestion(existingQuestion.id!!)
+
+        // then
+        assertEquals("테스트 제목", question.title)
+        assertEquals("테스트 내용", question.content)
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #19 

## 작업 내용

- [x] QuestionController와 QuestionService에 findQuestion 메서드 추가
- [x] QuestionService 내 questionId로 Question 엔티티를 조회하는 내부 메서드 생성
- [x] 질문 단건 조회 기능 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
