### PR TITLE
[Feat] 질문 단건 조회 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -22,5 +22,10 @@ class QuestionController(
     @GetMapping("/{questionId}")
     @Description("질문 단건 조회")
     fun findQuestion(@PathVariable questionId: Long) =
-        questionService.findQuestion(questionId)
+        ResponseEntity.ok().body(questionService.findQuestion(questionId))
+
+    @GetMapping
+    @Description("질문 목록 조회")
+    fun findQuestions(@RequestParam page: Int) =
+        ResponseEntity.ok().body(questionService.findQuestions(page))
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -6,6 +6,9 @@ import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import org.springframework.context.annotation.Description
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -28,4 +31,13 @@ class QuestionService(
     fun findQuestion(questionId: Long) =
         getQuestionById(questionId)
             .let { QuestionResponse.from(it) }
+
+    @Description("질문 목록 조회")
+    fun findQuestions(page: Int) =
+        PageRequest.of(page - 1, QUESTION_PAGE_SIZE, Sort.by(DESC, "id"))
+            .let { questionRepository.findAll(it).map { q -> QuestionResponse.from(q) } }
+
+    companion object {
+        private const val QUESTION_PAGE_SIZE = 10
+    }
 }

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -51,7 +51,34 @@ class QuestionServiceTest {
         val question = questionService.findQuestion(existingQuestion.id!!)
 
         // then
+        assertEquals(existingQuestion.id, question.id)
         assertEquals("테스트 제목", question.title)
         assertEquals("테스트 내용", question.content)
+    }
+
+    @Test
+    @DisplayName("질문 목록 조회")
+    fun findQuestions() {
+        // given
+        (1..AMOUNT_OF_QUESTIONS).forEach {
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목${it}", content = "테스트 내용${it}")
+                .let { q -> questionRepository.save(q) }
+        }
+
+        // when
+        val firstPage = questionService.findQuestions(1)
+        val lastPage = questionService.findQuestions(AMOUNT_OF_QUESTIONS / QUESTION_PAGE_SIZE)
+
+        // then
+        assertEquals(QUESTION_PAGE_SIZE, firstPage.size)
+        assertEquals("테스트 제목${AMOUNT_OF_QUESTIONS}", firstPage.first().title)
+        assertEquals("테스트 내용${AMOUNT_OF_QUESTIONS}", firstPage.first().content)
+        assertEquals("테스트 제목1", lastPage.last().title)
+        assertEquals("테스트 내용1", lastPage.last().content)
+    }
+
+    companion object {
+        const val QUESTION_PAGE_SIZE = 10 // 한 페이지의 크기
+        const val AMOUNT_OF_QUESTIONS = 50 // 페이징 테스트를 위해 만든 더미 질문의 개수
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #23

## 작업 내용

- [x] QuestionController와 QuestionService에 findQuestions 메서드 추가
- [x] 한 페이지 당 10개의 질문이 출력, id 기준 내림차순 적용
- [x] 질문 목록 조회 기능 및 페이징 작동 여 테스트 코드 추가

## 리뷰 요구사항 (선택)

추후에 QueryDsl을 활용한 페이징으로 전환할지 고민중