### PR TITLE
[Settings] QueryDSL을 사용하기 위한 기본 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 	kotlin("jvm") version "1.9.24"
 	kotlin("plugin.spring") version "1.9.24"
 	kotlin("plugin.jpa") version "1.9.24"
+	kotlin("kapt") version "2.0.0"
 }
 
 group = "hunzz.study"
@@ -23,6 +24,9 @@ dependencies {
 	// DB
 	runtimeOnly("com.h2database:h2")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	// QUERYDSL
+	implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
 	// SWAGGER
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 	// TEST

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepository.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface QuestionRepository : JpaRepository<Question, Long>
+interface QuestionRepository : JpaRepository<Question, Long>, QuestionRepositoryCustom

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryCustom.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryCustom.kt
@@ -1,0 +1,6 @@
+package hunzz.study.moorobo.domain.question.repository
+
+import org.springframework.stereotype.Repository
+
+@Repository
+interface QuestionRepositoryCustom

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package hunzz.study.moorobo.domain.question.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import hunzz.study.moorobo.domain.question.model.QQuestion
+import hunzz.study.moorobo.global.config.QueryDslConfig
+import org.springframework.stereotype.Repository
+
+@Repository
+class QuestionRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : QueryDslConfig(), QuestionRepositoryCustom {
+    private val question = QQuestion.question
+}

--- a/src/main/kotlin/hunzz/study/moorobo/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package hunzz.study.moorobo.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+abstract class QueryDslConfig {
+    @PersistenceContext
+    protected lateinit var em: EntityManager
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(em)
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #25 

## 작업 내용

- [x] build.gradle에 kapt 플러그인 추가 및 QueryDSL 관련 의존성 추입
- [x] JPAQueryFactory을 Bean에 등록하기 위한 QueryDslConfig 클래스 추가
- [x] QueryDSL을 사용하기 위한 Question 관련 2개의 추가적인 Repository 생성 -> QuestionRepositoryCustom, QuestionRepositoryImpl

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
