### PR TITLE
[BugFix] QueryDslConfig와 QuestionRepositoryImpl 간 Bean 순환 참조 에러 해결

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
@@ -1,13 +1,9 @@
 package hunzz.study.moorobo.domain.question.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import hunzz.study.moorobo.domain.question.model.QQuestion
-import hunzz.study.moorobo.global.config.QueryDslConfig
 import org.springframework.stereotype.Repository
 
 @Repository
 class QuestionRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
-) : QueryDslConfig(), QuestionRepositoryCustom {
-    private val question = QQuestion.question
-}
+) : QuestionRepositoryCustom

--- a/src/main/kotlin/hunzz/study/moorobo/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/config/QueryDslConfig.kt
@@ -7,10 +7,10 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-abstract class QueryDslConfig {
+class QueryDslConfig {
     @PersistenceContext
     protected lateinit var em: EntityManager
 
     @Bean
-    fun jpaQueryFactory() = JPAQueryFactory(em)
+    protected fun jpaQueryFactory() = JPAQueryFactory(em)
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #27 

## 작업 내용

- [ ] QueryDslConfig을 추상 클래스가 아닌 일반 클래스로 변경
- [ ] QuestionRepositoryImpl이 QueryDslConfig를 상속받는 것이 아닌, JPAQueryFactory를 주입받는 것으로 변경

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
