### PR TITLE
[Feat] 질문 목록 조회 기능 구현 (QueryDSL 적용)

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -26,6 +26,6 @@ class QuestionController(
 
     @GetMapping
     @Description("질문 목록 조회")
-    fun findQuestions(@RequestParam page: Int) =
+    fun findQuestions(@RequestParam(defaultValue = "1") page: Int) =
         ResponseEntity.ok().body(questionService.findQuestions(page))
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryCustom.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryCustom.kt
@@ -1,6 +1,11 @@
 package hunzz.study.moorobo.domain.question.repository
 
+import hunzz.study.moorobo.domain.question.model.Question
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
-interface QuestionRepositoryCustom
+interface QuestionRepositoryCustom {
+    fun findQuestions(pageable: Pageable): Page<Question>
+}

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/repository/QuestionRepositoryImpl.kt
@@ -1,9 +1,31 @@
 package hunzz.study.moorobo.domain.question.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import hunzz.study.moorobo.domain.question.model.QQuestion
+import org.springframework.context.annotation.Description
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
 class QuestionRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
-) : QuestionRepositoryCustom
+) : QuestionRepositoryCustom {
+    private val question = QQuestion.question
+
+    @Description("질문 목록을 조회하는 메서드")
+    override fun findQuestions(pageable: Pageable) =
+        PageImpl(getContents(pageable), pageable, getTotalElements())
+
+    @Description("페이지에 포함될 질문 데이터를 가져오는 내부 메서드")
+    private fun getContents(pageable: Pageable) =
+        jpaQueryFactory.selectFrom(question)
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .orderBy(question.id.desc())
+            .fetch()
+
+    @Description("전체 질문 개수를 가져오는 내부 메서드")
+    private fun getTotalElements() =
+        jpaQueryFactory.select(question.count()).from(question).fetchOne() ?: 0L
+}

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -7,8 +7,6 @@ import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import org.springframework.context.annotation.Description
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
-import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -32,10 +30,15 @@ class QuestionService(
         getQuestionById(questionId)
             .let { QuestionResponse.from(it) }
 
-    @Description("질문 목록 조회")
+//    @Description("질문 목록 조회 (v1: QueryDSL 미사용)")
+//    fun findQuestions(page: Int) =
+//        PageRequest.of(page - 1, QUESTION_PAGE_SIZE, Sort.by(DESC, "id"))
+//            .let { questionRepository.findAll(it).map { q -> QuestionResponse.from(q) } }
+
+    @Description("질문 목록 조회 (v2: QueryDSL 사용)")
     fun findQuestions(page: Int) =
-        PageRequest.of(page - 1, QUESTION_PAGE_SIZE, Sort.by(DESC, "id"))
-            .let { questionRepository.findAll(it).map { q -> QuestionResponse.from(q) } }
+        PageRequest.of(page - 1, QUESTION_PAGE_SIZE)
+            .let { questionRepository.findQuestions(it).map { q -> QuestionResponse.from(q) } }
 
     companion object {
         private const val QUESTION_PAGE_SIZE = 10

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -135,6 +135,26 @@ class QuestionControllerTest {
             .andDo(print())
     }
 
+    @Test
+    @DisplayName("정상적으로 질문 목록이 페이징이 적용된 채 조회된 경우 (page에 값을 대입 X)")
+    fun findQuestions2() {
+        // given
+        (1..AMOUNT_OF_QUESTIONS).forEach {
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목${it}", content = "테스트 내용${it}")
+                .let { q -> questionRepository.save(q) }
+        }
+
+        // expected
+        mockMvc.perform(
+            get("/questions")
+                .contentType(APPLICATION_JSON)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.content.size()").value(QUESTION_PAGE_SIZE))
+            .andExpect(jsonPath("$.content[0].title").value("테스트 제목${AMOUNT_OF_QUESTIONS}"))
+            .andExpect(jsonPath("$.content[0].content").value("테스트 내용${AMOUNT_OF_QUESTIONS}"))
+            .andDo(print())
+    }
+
     companion object {
         const val QUESTION_PAGE_SIZE = 10 // 한 페이지의 크기
         const val AMOUNT_OF_QUESTIONS = 50 // 페이징 테스트를 위해 만든 더미 질문의 개수


### PR DESCRIPTION
## 연관된 이슈

- closes #29 

## 작업 내용

- [x] QuestionService에서 Pageable 객체를 만들어 QuestionRepositoryImpl로 전달
- [x] QuestionRepositoryCustom에 질문을 조회하는 findQuestions 메서드 정의
- [x] QuestionRepositoryImpl에서 findQuestion 메서드 구현
- [x] QuestionController에서 page의 defaultValue를 1로 지정
- [x] page에 값을 대입하지 않은 경우의 테스트 케이스 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
