### PR TITLE
[Feat] 질문 수정 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -1,6 +1,7 @@
 package hunzz.study.moorobo.domain.question.controller
 
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.service.QuestionService
 import jakarta.validation.Valid
 import org.springframework.context.annotation.Description
@@ -28,4 +29,9 @@ class QuestionController(
     @Description("질문 목록 조회")
     fun findQuestions(@RequestParam(defaultValue = "1") page: Int) =
         ResponseEntity.ok().body(questionService.findQuestions(page))
+
+    @PutMapping("/{questionId}")
+    @Description("질문 수정")
+    fun updateQuestion(@PathVariable questionId: Long, @Valid @RequestBody request: UpdateQuestionRequest) =
+        ResponseEntity.ok().body(questionService.updateQuestion(questionId, request))
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/UpdateQuestionRequest.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/UpdateQuestionRequest.kt
@@ -1,0 +1,13 @@
+package hunzz.study.moorobo.domain.question.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateQuestionRequest(
+    @field:NotBlank(message = "질문의 제목은 필수 입력 항목입니다.")
+    @field:Size(max = 128, message = "질문의 제목은 128자 이하여야 합니다.")
+    val title: String,
+
+    @field:NotBlank(message = "질문의 내용은 필수 입력 항목입니다.")
+    val content: String
+)

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
@@ -11,14 +11,20 @@ class Question(
     val status: QuestionStatus,
 
     @Column(name = "title", nullable = false)
-    val title: String,
+    var title: String,
 
     @Lob
     @Column(name = "content", nullable = false)
-    val content: String
+    var content: String
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "question_id", nullable = false, unique = true)
     val id: Long? = null
+
+    fun update(title: String, content: String): Question {
+        this.title = title
+        this.content = content
+        return this
+    }
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -2,9 +2,11 @@ package hunzz.study.moorobo.domain.question.service
 
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
 import hunzz.study.moorobo.domain.question.dto.QuestionResponse
+import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
+import jakarta.transaction.Transactional
 import org.springframework.context.annotation.Description
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
@@ -39,6 +41,12 @@ class QuestionService(
     fun findQuestions(page: Int) =
         PageRequest.of(page - 1, QUESTION_PAGE_SIZE)
             .let { questionRepository.findQuestions(it).map { q -> QuestionResponse.from(q) } }
+
+    @Transactional
+    @Description("질문 수정")
+    fun updateQuestion(questionId: Long, request: UpdateQuestionRequest) =
+        getQuestionById(questionId).update(title = request.title, content = request.content)
+            .let { QuestionResponse.from(it) }
 
     companion object {
         private const val QUESTION_PAGE_SIZE = 10

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -2,6 +2,7 @@ package hunzz.study.moorobo.domain.question.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
@@ -13,8 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -153,6 +153,28 @@ class QuestionControllerTest {
             .andExpect(jsonPath("$.content[0].title").value("테스트 제목${AMOUNT_OF_QUESTIONS}"))
             .andExpect(jsonPath("$.content[0].content").value("테스트 내용${AMOUNT_OF_QUESTIONS}"))
             .andDo(print())
+    }
+
+    @Test
+    @DisplayName("정상적으로 질문이 수정되는 경우")
+    fun updateQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+        val json = objectMapper.writeValueAsString(
+            UpdateQuestionRequest(title = "수정된 테스트 제목", content = "수정된 테스트 내용")
+        )
+
+        // expected
+        mockMvc.perform(
+            put("/questions/{questionId}", existingQuestion.id)
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(existingQuestion.id))
+            .andExpect(jsonPath("$.title").value("수정된 테스트 제목"))
+            .andExpect(jsonPath("$.content").value("수정된 테스트 내용"))
     }
 
     companion object {

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -1,6 +1,7 @@
 package hunzz.study.moorobo.domain.question.service
 
 import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
+import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
@@ -75,6 +76,24 @@ class QuestionServiceTest {
         assertEquals("테스트 내용${AMOUNT_OF_QUESTIONS}", firstPage.first().content)
         assertEquals("테스트 제목1", lastPage.last().title)
         assertEquals("테스트 내용1", lastPage.last().content)
+    }
+
+    @Test
+    @DisplayName("질문 수정")
+    fun updateQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+        val request = UpdateQuestionRequest(title = "수정된 테스트 제목", content = "수정된 테스트 내용")
+
+        // when
+        val question = questionService.updateQuestion(existingQuestion.id!!, request)
+
+        // then
+        assertEquals(true, existingQuestion.id == question.id)
+        assertEquals("수정된 테스트 제목", question.title)
+        assertEquals("수정된 테스트 내용", question.content)
     }
 
     companion object {


### PR DESCRIPTION


## 연관된 이슈

- closes #31 

## 작업 내용

- [x] QuestionController와 QuestionService에 addQuestion 메서드 추가
- [x] 질문 등록 관련 데이터를 받아올 AddQuestionRequest DTO 클래스 생성 및 Validation 적용
- [x] 해당 질문 등록 후, 관련 데이터를 전달할 QuestionResponse DTO 클래스 생성
- [x] 질문 등록 기능 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
