### PR TITLE
[Feat] 질문 삭제 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionController.kt
@@ -34,4 +34,9 @@ class QuestionController(
     @Description("질문 수정")
     fun updateQuestion(@PathVariable questionId: Long, @Valid @RequestBody request: UpdateQuestionRequest) =
         ResponseEntity.ok().body(questionService.updateQuestion(questionId, request))
+
+    @DeleteMapping("/{questionId}")
+    @Description("질문 삭제")
+    fun deleteQuestion(@PathVariable questionId: Long) =
+        ResponseEntity.ok().body(questionService.deleteQuestion(questionId))
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/model/Question.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 class Question(
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    val status: QuestionStatus,
+    var status: QuestionStatus,
 
     @Column(name = "title", nullable = false)
     var title: String,
@@ -26,5 +26,9 @@ class Question(
         this.title = title
         this.content = content
         return this
+    }
+
+    fun delete() {
+        this.status = QuestionStatus.DELETED
     }
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -4,6 +4,7 @@ import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
 import hunzz.study.moorobo.domain.question.dto.QuestionResponse
 import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
+import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import jakarta.transaction.Transactional
@@ -47,6 +48,11 @@ class QuestionService(
     fun updateQuestion(questionId: Long, request: UpdateQuestionRequest) =
         getQuestionById(questionId).update(title = request.title, content = request.content)
             .let { QuestionResponse.from(it) }
+
+    @Transactional
+    @Description("질문 삭제")
+    fun deleteQuestion(questionId: Long) =
+        getQuestionById(questionId).delete()
 
     companion object {
         private const val QUESTION_PAGE_SIZE = 10

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -175,6 +175,23 @@ class QuestionControllerTest {
             .andExpect(jsonPath("$.id").value(existingQuestion.id))
             .andExpect(jsonPath("$.title").value("수정된 테스트 제목"))
             .andExpect(jsonPath("$.content").value("수정된 테스트 내용"))
+            .andDo(print())
+    }
+
+    @Test
+    @DisplayName("정상적으로 질문이 삭제되는 경우")
+    fun deleteQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // expected
+        mockMvc.perform(
+            delete("/questions/{questionId}", existingQuestion.id)
+                .contentType(APPLICATION_JSON)
+        ).andExpect(status().isOk)
+            .andDo(print())
     }
 
     companion object {

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 
 @SpringBootTest
 class QuestionServiceTest {
@@ -94,6 +95,25 @@ class QuestionServiceTest {
         assertEquals(true, existingQuestion.id == question.id)
         assertEquals("수정된 테스트 제목", question.title)
         assertEquals("수정된 테스트 내용", question.content)
+    }
+
+    @Test
+    @DisplayName("질문 삭제")
+    fun deleteQuestion() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // when
+        questionService.deleteQuestion(existingQuestion.id!!)
+        val question = questionRepository.findByIdOrNull(existingQuestion.id)!!
+
+        // then
+        assertEquals(1, questionRepository.count())
+        assertEquals(QuestionStatus.DELETED, question.status)
+        assertEquals(existingQuestion.title, question.title)
+        assertEquals(existingQuestion.content, question.content)
     }
 
     companion object {


### PR DESCRIPTION
## 연관된 이슈

- closes #33 

## 작업 내용

- [x] QuestionController와 QuestionService에 deleteQuestion 메서드 추가
- [x] Question 엔티티 내 delete 메서드 추가 -> soft delete로 status만 DELETED로 변경
- [x] 질문 삭제 기능 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
