### PR TITLE
[Feat] ModelNotFoundException에 대한 테스트 코드 추가

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/service/QuestionService.kt
@@ -4,7 +4,6 @@ import hunzz.study.moorobo.domain.question.dto.AddQuestionRequest
 import hunzz.study.moorobo.domain.question.dto.QuestionResponse
 import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
-import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import jakarta.transaction.Transactional

--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/ExceptionHandler.kt
@@ -24,5 +24,8 @@ class ExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(ModelNotFoundException::class)
     fun handleModelNotFoundException(e: ModelNotFoundException) =
-        ErrorResponse().addError(null, e.message!!)
+        ErrorResponse().let {
+            it.addError(null, e.message!!)
+            it
+        }
 }

--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/case/ModelNotFoundException.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/case/ModelNotFoundException.kt
@@ -1,3 +1,12 @@
 package hunzz.study.moorobo.global.exception.case
 
-class ModelNotFoundException(value: String) : RuntimeException("존재하지 않는 ${value}입니다.")
+import hunzz.study.moorobo.domain.question.model.Question
+
+class ModelNotFoundException(value: String) : RuntimeException(
+    "존재하지 않는 ${
+        when (value) {
+            Question::class.simpleName.toString() -> "질문"
+            else -> ""
+        }
+    }입니다."
+)

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -56,7 +56,7 @@ class QuestionControllerTest {
     }
 
     @Test
-    @DisplayName("질문의 내용을 미입력한 경우")
+    @DisplayName("질문 등록 시, 질문의 내용을 미입력한 경우")
     fun addQuestionException1() {
         // given
         val json = objectMapper.writeValueAsString(
@@ -76,7 +76,7 @@ class QuestionControllerTest {
     }
 
     @Test
-    @DisplayName("128자를 초과하는 질문 제목이 등록된 경우")
+    @DisplayName("질문 등록 시, 128자를 초과하는 질문 제목이 등록된 경우")
     fun addQuestionException2() {
         // given
         val json = objectMapper.writeValueAsString(
@@ -112,6 +112,25 @@ class QuestionControllerTest {
             .andExpect(jsonPath("$.id").value(existingQuestion.id))
             .andExpect(jsonPath("$.title").value("테스트 제목"))
             .andExpect(jsonPath("$.content").value("테스트 내용"))
+            .andDo(print())
+    }
+
+    @Test
+    @DisplayName("질문 조회 시, id에 해당하는 질문이 존재하지 않는 경우")
+    fun findQuestionException() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // expected
+        mockMvc.perform(
+            get("/questions/{questionId}", existingQuestion.id!! + 1)
+        ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.errors").isArray)
+            .andExpect(jsonPath("$.errors.size()").value(1))
+            .andExpect(jsonPath("$.errors[0].field").value(null))
+            .andExpect(jsonPath("$.errors[0].message").value("존재하지 않는 질문입니다."))
             .andDo(print())
     }
 

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -5,7 +5,9 @@ import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
+import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -56,6 +58,20 @@ class QuestionServiceTest {
         assertEquals(existingQuestion.id, question.id)
         assertEquals("테스트 제목", question.title)
         assertEquals("테스트 내용", question.content)
+    }
+
+    @Test
+    @DisplayName("질문 단건 조회 시, 존재하지 않는 id를 대입한 경우 (ModelNotFoundException)")
+    fun findQuestionException() {
+        // given
+        val existingQuestion =
+            Question(status = QuestionStatus.NORMAL, title = "테스트 제목", content = "테스트 내용")
+                .let { questionRepository.save(it) }
+
+        // expected
+        assertThrows(ModelNotFoundException::class.java) {
+            questionService.findQuestion(existingQuestion.id!! + 1)
+        }.let { assertEquals("존재하지 않는 질문입니다.", it.message) }
     }
 
     @Test


### PR DESCRIPTION
## 연관된 이슈

- closes #35

## 작업 내용

- [x] ModelNotFoundException 테스트 코드 추가
- [x] ModelNotFoundException의 에러 메시지 수정 -> "존재하지 않는 ${value}입니다." 의 value를 한글로 수정
- [x] ExceptionHandler 내 ModelNotFoundException 제어 메서드의 리턴값을 ErrorResponse로 수정

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
