### PR TITLE
[Feat] 비속어 필터링을 위한 예외 케이스 추가 (BannedWordInQuestionException)

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/ErrorResponse.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/ErrorResponse.kt
@@ -3,7 +3,7 @@ package hunzz.study.moorobo.global.exception
 import java.time.LocalDateTime
 
 data class ErrorResponse(
-    val errors: MutableList<Error> = mutableListOf(),
+    var errors: MutableList<Error> = mutableListOf(),
     val time: LocalDateTime = LocalDateTime.now()
 ) {
     fun addError(field: String?, message: String) =

--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/ExceptionHandler.kt
@@ -1,7 +1,9 @@
 package hunzz.study.moorobo.global.exception
 
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
+import hunzz.study.moorobo.global.exception.case.QuestionException
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -28,4 +30,14 @@ class ExceptionHandler {
             it.addError(null, e.message!!)
             it
         }
+
+    // Question 관련 예외 처리
+    @ExceptionHandler(QuestionException::class)
+    fun handleQuestionException(e: QuestionException) =
+        ResponseEntity.status(Integer.parseInt(e.statusCode)).body(
+            ErrorResponse().let {
+                it.errors = e.errors
+                it
+            }
+        )
 }

--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/case/BannedWordInQuestionException.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/case/BannedWordInQuestionException.kt
@@ -1,0 +1,17 @@
+package hunzz.study.moorobo.global.exception.case
+
+class BannedWordInQuestionException(field: String) : QuestionException(
+    "${
+        when (field) {
+            "title" -> "질문 제목"
+            "content" -> "질문 내용"
+            else -> ""
+        }
+    }에 비속어가 포함되어 있습니다."
+) {
+    override val statusCode = "400"
+
+    init {
+        addError(field = field)
+    }
+}

--- a/src/main/kotlin/hunzz/study/moorobo/global/exception/case/QuestionException.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/exception/case/QuestionException.kt
@@ -1,0 +1,10 @@
+package hunzz.study.moorobo.global.exception.case
+
+import hunzz.study.moorobo.global.exception.ErrorResponse.Error
+
+abstract class QuestionException(private val errorMessage: String) : RuntimeException(errorMessage) {
+    abstract val statusCode: String
+    val errors: MutableList<Error> = mutableListOf()
+
+    fun addError(field: String) = errors.add(Error(field = field, message = errorMessage))
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #37 

## 작업 내용

- [x] (추후에 생성될) 질문 관련 예외들의 상위 클래스인 QuestionException 생성 -> statusCode, errors 필드 추가
- [x] BannedWordInQuestionException 클래스 생성 후 QuestionException을 상속
- [x] ExceptionHandler에서 ResponseEntity의 status에는 QuestionException의 statusCode를, body 내 ErrorResponse의 errors에는 QuestionException의 errors를 대입(set)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
