### PR TITLE
[Feat] 질문 등록/수정 시, 비속어 필터링 기능 구현

### DIFF
--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/AddQuestionRequest.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/AddQuestionRequest.kt
@@ -2,8 +2,11 @@ package hunzz.study.moorobo.domain.question.dto
 
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.model.QuestionStatus
+import hunzz.study.moorobo.global.utility.BannedWordsFilter
+import hunzz.study.moorobo.global.exception.case.BannedWordInQuestionException
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import org.springframework.context.annotation.Description
 
 data class AddQuestionRequest(
     @field:NotBlank(message = "질문의 제목은 필수 입력 항목입니다.")
@@ -13,10 +16,19 @@ data class AddQuestionRequest(
     @field:NotBlank(message = "질문의 내용은 필수 입력 항목입니다.")
     val content: String
 ) {
-    // Request -> Entity
+    @Description("Request DTO 객체를 엔티티로 변환")
     fun to() = Question(
         status = QuestionStatus.NORMAL,
         title = this.title,
         content = this.content
     )
+
+    @Description("비속어 포함 여부 검증")
+    fun validate(bannedWordsFilter: BannedWordsFilter): AddQuestionRequest {
+        if (bannedWordsFilter.check(this.title))
+            throw BannedWordInQuestionException("title")
+        else if (bannedWordsFilter.check(this.content))
+            throw BannedWordInQuestionException("content")
+        else return this
+    }
 }

--- a/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/UpdateQuestionRequest.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/domain/question/dto/UpdateQuestionRequest.kt
@@ -1,7 +1,10 @@
 package hunzz.study.moorobo.domain.question.dto
 
+import hunzz.study.moorobo.global.utility.BannedWordsFilter
+import hunzz.study.moorobo.global.exception.case.BannedWordInQuestionException
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import org.springframework.context.annotation.Description
 
 data class UpdateQuestionRequest(
     @field:NotBlank(message = "질문의 제목은 필수 입력 항목입니다.")
@@ -10,4 +13,13 @@ data class UpdateQuestionRequest(
 
     @field:NotBlank(message = "질문의 내용은 필수 입력 항목입니다.")
     val content: String
-)
+) {
+    @Description("비속어 포함 여부 검증")
+    fun validate(bannedWordsFilter: BannedWordsFilter): UpdateQuestionRequest {
+        if (bannedWordsFilter.check(this.title))
+            throw BannedWordInQuestionException("title")
+        else if (bannedWordsFilter.check(this.content))
+            throw BannedWordInQuestionException("content")
+        else return this
+    }
+}

--- a/src/main/kotlin/hunzz/study/moorobo/global/utility/BannedWords.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/utility/BannedWords.kt
@@ -1,0 +1,9 @@
+package hunzz.study.moorobo.global.utility
+
+interface BannedWords {
+    val bannedWords: List<String>
+        get() = listOf("욕설", "나쁜말", "아주나쁜말", "심한말")
+
+    val delimiters: List<String>
+        get() = listOf(" ", ",", ".", "!", "@", "?", "1")
+}

--- a/src/main/kotlin/hunzz/study/moorobo/global/utility/BannedWordsFilter.kt
+++ b/src/main/kotlin/hunzz/study/moorobo/global/utility/BannedWordsFilter.kt
@@ -1,0 +1,43 @@
+package hunzz.study.moorobo.global.utility
+
+import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Description
+import org.springframework.stereotype.Component
+import java.lang.String.join
+import java.util.regex.Pattern
+
+@Component
+class BannedWordsFilter : BannedWords {
+    val patterns = mutableMapOf<String, Pattern>() // { 비속어: 정규식 }
+
+    @PostConstruct
+    @Description("구분자를 활용한 다양한 형태의 비속어를 정의")
+    fun buildPattern() {
+        @Description("구분자 정규식 생성")
+        fun buildDelimitersPattern() =
+            StringBuilder().let {
+                // 정규식의 [ ]은 대괄호 내 문자와 매치하는지 여부를 판단
+                it.append("[")
+                delimiters.forEach { delimiter ->
+                    it.append(Pattern.quote(delimiter)) // 정규식 내 이스케이프 문자 처리
+                }
+                it.append("]*")
+            }.toString()
+
+        bannedWords.forEach { word ->
+            word.split("").toTypedArray() // ["욕", "설"]
+                .let {
+                    patterns[word] =
+                        Pattern.compile(
+                            join(buildDelimitersPattern(), *it) // "욕[구분자]설"
+                        ) // 문자열 -> 정규식
+                }
+        }
+    }
+
+    @Description("비속어 여부 체크")
+    fun check(str: String) =
+        patterns.values.any { pattern ->
+            pattern.matcher(str).find() //
+        }
+}

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/controller/QuestionControllerTest.kt
@@ -97,6 +97,48 @@ class QuestionControllerTest {
     }
 
     @Test
+    @DisplayName("질문 등록 시, 질문 내용에 비속어가 포함된 경우")
+    fun addQuestionException3() {
+        // given
+        val json = objectMapper.writeValueAsString(
+            AddQuestionRequest(title = "테스트 제목", content = "욕설이 포함된 테스트 내용")
+        )
+
+        // expected
+        mockMvc.perform(
+            post("/questions")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errors").isArray)
+            .andExpect(jsonPath("$.errors.size()").value(1))
+            .andExpect(jsonPath("$.errors[0].field").value("content"))
+            .andExpect(jsonPath("$.errors[0].message").value("질문 내용에 비속어가 포함되어 있습니다."))
+            .andDo(print())
+    }
+
+    @Test
+    @DisplayName("질문 등록 시, 질문 내용에 구분자를 활용한 비속어가 포함된 경우")
+    fun addQuestionException4() {
+        // given
+        val json = objectMapper.writeValueAsString(
+            AddQuestionRequest(title = "테스트 제목", content = "욕1설이 포함된 테스트 내용")
+        )
+
+        // expected
+        mockMvc.perform(
+            post("/questions")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errors").isArray)
+            .andExpect(jsonPath("$.errors.size()").value(1))
+            .andExpect(jsonPath("$.errors[0].field").value("content"))
+            .andExpect(jsonPath("$.errors[0].message").value("질문 내용에 비속어가 포함되어 있습니다."))
+            .andDo(print())
+    }
+
+    @Test
     @DisplayName("정상적으로 질문이 조회된 경우")
     fun findQuestion() {
         // given

--- a/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
+++ b/src/test/kotlin/hunzz/study/moorobo/domain/question/service/QuestionServiceTest.kt
@@ -5,6 +5,7 @@ import hunzz.study.moorobo.domain.question.dto.UpdateQuestionRequest
 import hunzz.study.moorobo.domain.question.model.Question
 import hunzz.study.moorobo.domain.question.model.QuestionStatus
 import hunzz.study.moorobo.domain.question.repository.QuestionRepository
+import hunzz.study.moorobo.global.exception.case.BannedWordInQuestionException
 import hunzz.study.moorobo.global.exception.case.ModelNotFoundException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -44,6 +45,38 @@ class QuestionServiceTest {
     }
 
     @Test
+    @DisplayName("질문 등록 시, 제목이나 내용에 비속어가 포함된 경우 BannedWordInQuestionException")
+    fun addQuestionException1() {
+        // given
+        val request1 = AddQuestionRequest(title = "욕설이 포함된 테스트 제목", content = "테스트 내용")
+        val request2 = AddQuestionRequest(title = "테스트 제목", content = "테스트 내용 내 욕설 포함")
+
+        // expected
+        assertThrows(BannedWordInQuestionException::class.java) {
+            questionService.addQuestion(request1)
+        }.let { assertEquals("질문 제목에 비속어가 포함되어 있습니다.", it.message) }
+        assertThrows(BannedWordInQuestionException::class.java) {
+            questionService.addQuestion(request2)
+        }.let { assertEquals("질문 내용에 비속어가 포함되어 있습니다.", it.message) }
+    }
+
+    @Test
+    @DisplayName("질문 등록 시, 제목이나 내용에 구분자를 활용한 비속어가 포함된 경우 BannedWordInQuestionException")
+    fun addQuestionException2() {
+        // given
+        val request1 = AddQuestionRequest(title = "욕1설이 포함된 테스트 제목", content = "테스트 내용")
+        val request2 = AddQuestionRequest(title = "테스트 제목", content = "테스트 내용 내 욕@설 포함")
+
+        // expected
+        assertThrows(BannedWordInQuestionException::class.java) {
+            questionService.addQuestion(request1)
+        }.let { assertEquals("질문 제목에 비속어가 포함되어 있습니다.", it.message) }
+        assertThrows(BannedWordInQuestionException::class.java) {
+            questionService.addQuestion(request2)
+        }.let { assertEquals("질문 내용에 비속어가 포함되어 있습니다.", it.message) }
+    }
+
+    @Test
     @DisplayName("질문 단건 조회")
     fun findQuestion() {
         // given
@@ -61,7 +94,7 @@ class QuestionServiceTest {
     }
 
     @Test
-    @DisplayName("질문 단건 조회 시, 존재하지 않는 id를 대입한 경우 (ModelNotFoundException)")
+    @DisplayName("질문 단건 조회 시, 존재하지 않는 id를 대입한 경우 ModelNotFoundException")
     fun findQuestionException() {
         // given
         val existingQuestion =


### PR DESCRIPTION
## 연관된 이슈

- closes #39 

## 작업 내용

- [x] BannedWords 인터페이스를 생성하고, 비속어와 구분자(!, @, ? 등) 목록을 정의
- [x] 비속어를 검증하는 BannedWordsFilter 클래스를 생성하고 Component로 등록
- [x] AddQuestionRequest와 UpdateQuestionRequest에 검증 메서드(validate) 추가
- [x] QuestionService에서 BannedWordsFilter를 주입받음
- [x] 비속어 필터링 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
